### PR TITLE
Remove reference to normalize.css because it is unused

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" href="css/normalize.css" />
     <link rel="stylesheet" href="css/skeleton.css" />
     <link rel="stylesheet" href="css/style.css" />
     <title>Mobile Native Foundation</title>


### PR DESCRIPTION
Hello,

I suggest to remove reference to `normalize.css` because currently most of its code is unused and the rest (~5%) in use is either redefined or canceled with `skeleton.css` or `style.css`.

Checked with Coverage tool and manual comparison.

![image](https://user-images.githubusercontent.com/43063763/112870857-d5e06f00-90e8-11eb-9f07-63bc8f73b431.png)

Regards,
