### PR TITLE
Update link and banner styling for improved contrast

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -20,6 +20,14 @@ h4 {
   line-height: 1.5em;
 }
 
+a {
+  color: #0c60ff;
+}
+
+a:hover {
+  color: #0c60ffaa;
+}
+
 .support {
   font-weight: bold;
 }
@@ -29,7 +37,7 @@ h4 {
 }
 
 .cta {
-  background-color: #30bced;
+  background-color: #0c60ff;
   border-radius: 0.4em;
   color: white;
   display: inline-block;
@@ -40,7 +48,7 @@ h4 {
 }
 
 .cta:hover {
-  background-color: #129cce;
+  background-color: #0c60ffaa;
   color: white;
 }
 
@@ -74,7 +82,7 @@ footer {
 
 .banner {
   padding: 2em 0 0.5em;
-  background-color: #FFEA00;
+  border: 3px solid #FF9F10;
   text-align: center;
   border-radius: 1em;
   margin: 0 auto;


### PR DESCRIPTION
The existing link color didn't pass the contrast guidelines for accessibility; and the yellow banner with the blue link was particularly egregious. I'm no designer, but I took a pass at improving legibility while still highlighting the content - open to feedback!

<img width="2672" alt="Screenshot 2023-02-22 at 9 08 48 AM" src="https://user-images.githubusercontent.com/3526783/220704070-43766b46-f511-4c88-8e4b-48b85905aea2.png">
